### PR TITLE
Support running inside a container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,44 @@ jobs:
     - run: test ${{ steps.setup3.outputs.mpi }} == intelmpi
     - run: command -v impi_info
 
+  container:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - debian
+          - ubuntu
+    container: ${{ matrix.image }}
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup MPICH
+      id:   setup1
+      uses: ./
+      with:
+        mpi: mpich
+    - run: test ${{ steps.setup1.outputs.mpi }} = mpich
+    - run: command -v mpichversion
+
+    - name: Setup Open MPI
+      id:   setup2
+      uses: ./
+      with:
+        mpi: openmpi
+    - run: test ${{ steps.setup2.outputs.mpi }} = openmpi
+    - run: command -v ompi_info
+
+    - name: Setup Intel MPI
+      id:   setup3
+      uses: ./
+      with:
+        mpi: intelmpi
+    - run: test ${{ steps.setup3.outputs.mpi }} = intelmpi
+    - run: command -v impi_info
+
   macOS:
     runs-on: macos-latest
     steps:

--- a/setup-mpi.sh
+++ b/setup-mpi.sh
@@ -18,7 +18,15 @@ case $MPI in
         ;;
 esac
 
+sudo () {
+    [ $(id -u) -eq 0 ] || set -- command sudo "$@"
+    "$@"
+}
+
 setup-apt-intel-oneapi () {
+    # ensure the required packages are installed
+    sudo apt update
+    sudo apt install -y -q ca-certificates curl gnupg procps
     apt_repo_url=https://apt.repos.intel.com/
     gpg_key_url=$apt_repo_url/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
     keyring=/usr/share/keyrings/oneapi-archive-keyring.gpg


### PR DESCRIPTION
Add support for running inside a (Debian-like) `container` by dropping `sudo` from commands when the user is `root` and ensuring that the required packages are installed. Also adds a new test job to confirm that this works.